### PR TITLE
fix: parameterize hook script paths for remotes

### DIFF
--- a/lefthook/common.yml
+++ b/lefthook/common.yml
@@ -15,61 +15,61 @@ pre-commit:
         piped: true
         jobs:
           - name: check-partial-stage
-            run: bash scripts/common/check-partial-stage.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-partial-stage.sh
             interactive: true
           - name: quality-gates
             group:
               parallel: true
               jobs:
                 - name: check-branch
-                  run: bash scripts/common/check-branch.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-branch.sh
                 - name: check-large-files
-                  run: bash scripts/common/check-large-files.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-large-files.sh
                 - name: check-file-length
-                  run: bash scripts/common/check-file-length.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-file-length.sh
                 - name: check-commit-size
-                  run: bash scripts/common/check-commit-size.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-commit-size.sh
                 - name: check-secrets
-                  run: bash scripts/common/check-secrets.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-secrets.sh
                 - name: check-sensitive-files
-                  run: bash scripts/common/check-sensitive-files.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-sensitive-files.sh
                 - name: check-paths
-                  run: bash scripts/common/check-paths.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-paths.sh
                 - name: check-todo
-                  run: bash scripts/common/check-todo.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-todo.sh
                 - name: check-naming
-                  run: bash scripts/common/check-naming.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-naming.sh
                 - name: check-format
-                  run: bash scripts/common/check-format.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-format.sh
                 - name: check-markdown-lint
                   glob: '**/*.md'
                   run: markdownlint-cli2 {staged_files}
                 - name: check-spelling
-                  run: bash scripts/common/check-spelling.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-spelling.sh
                 - name: check-markdown-links
-                  run: bash scripts/common/check-markdown-links.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-markdown-links.sh
                 - name: check-license-header
-                  run: bash scripts/common/license-header.sh check --staged
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/license-header.sh check --staged
 
 commit-msg:
   commands:
     validate-commit-msg:
-      run: bash scripts/common/validate-commit-msg.sh {1}
+      run: bash ${HOOKS_SCRIPTS:-scripts}/common/validate-commit-msg.sh {1}
 
 post-checkout:
   commands:
     check-branch-name:
-      run: bash scripts/common/check-branch-name.sh {0} {1} {2}
+      run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-branch-name.sh {0} {1} {2}
 
 post-commit:
   commands:
     check-signing:
-      run: bash scripts/common/check-signing.sh
+      run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-signing.sh
 
 pre-rebase:
   commands:
     check-rebase:
-      run: bash scripts/common/check-rebase.sh {1} {2}
+      run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-rebase.sh {1} {2}
 
 pre-push:
   jobs:
@@ -78,11 +78,11 @@ pre-push:
         piped: true
         jobs:
           - name: check-uncommitted
-            run: bash scripts/common/check-uncommitted.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-uncommitted.sh
             interactive: true
           - name: push-gates
             group:
               parallel: true
               jobs:
                 - name: check-signing
-                  run: bash scripts/common/check-signing.sh
+                  run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-signing.sh

--- a/lefthook/go.yml
+++ b/lefthook/go.yml
@@ -8,13 +8,13 @@ pre-commit:
         parallel: true
         jobs:
           - name: check-naming
-            run: bash scripts/go/check-naming.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/go/check-naming.sh
           - name: check-format
-            run: bash scripts/go/check-format.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/go/check-format.sh
           - name: check-lint
-            run: bash scripts/go/check-lint.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/go/check-lint.sh
 
 pre-push:
   jobs:
     - name: go-coverage
-      run: bash scripts/go/coverage.sh
+      run: bash ${HOOKS_SCRIPTS:-scripts}/go/coverage.sh

--- a/lefthook/node.yml
+++ b/lefthook/node.yml
@@ -8,9 +8,9 @@ pre-commit:
         parallel: true
         jobs:
           - name: check-naming
-            run: bash scripts/node/check-naming.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/node/check-naming.sh
 
 pre-push:
   jobs:
     - name: node-coverage
-      run: bash scripts/node/coverage.sh
+      run: bash ${HOOKS_SCRIPTS:-scripts}/node/coverage.sh

--- a/lefthook/python.yml
+++ b/lefthook/python.yml
@@ -8,13 +8,13 @@ pre-commit:
         parallel: true
         jobs:
           - name: check-naming
-            run: bash scripts/python/check-naming.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/python/check-naming.sh
           - name: check-format
-            run: bash scripts/python/check-format.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/python/check-format.sh
           - name: check-lint
-            run: bash scripts/python/check-lint.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/python/check-lint.sh
 
 pre-push:
   jobs:
     - name: python-coverage
-      run: bash scripts/python/coverage.sh
+      run: bash ${HOOKS_SCRIPTS:-scripts}/python/coverage.sh

--- a/lefthook/shell.yml
+++ b/lefthook/shell.yml
@@ -8,7 +8,7 @@ pre-commit:
         parallel: true
         jobs:
           - name: check-naming
-            run: bash scripts/shell/check-naming.sh
+            run: bash ${HOOKS_SCRIPTS:-scripts}/shell/check-naming.sh
           - name: check-format
             glob: '**/*.sh'
             run: shfmt -d {staged_files}
@@ -19,4 +19,4 @@ pre-commit:
 pre-push:
   jobs:
     - name: shell-coverage
-      run: bash scripts/shell/coverage.sh --docker
+      run: bash ${HOOKS_SCRIPTS:-scripts}/shell/coverage.sh --docker


### PR DESCRIPTION
## Summary                                                                                                                                                  
                                                                                                                                                            
  - Replace hardcoded `scripts/` prefix with `${HOOKS_SCRIPTS:-scripts}/` in all `run:` paths across 5 lefthook configs (31 paths total)                      
  - Defaults to `scripts/` in core-actions — no behavior change locally                                                                                       
  - Consumer repos set `HOOKS_SCRIPTS` via `.lefthookrc` to resolve scripts from lefthook's remote cache                                                      
                                                                                                                                                              
  ## Context

  Lefthook's `remotes:` fetches config YAML only — `run:` commands execute relative to the consumer repo's root, where `scripts/` doesn't exist. The remote
  clone at `.git/info/lefthook-remotes/<name>/` has the scripts, but they weren't reachable.

  ### Consumer repo setup

  ```yaml
  # lefthook.yml
  rc: .lefthookrc
  remotes:
    - git_url: git@github.com:leaflockio/core-actions.git
      ref: v1
      configs:
        - lefthook/common.yml

  # .lefthookrc
  export HOOKS_SCRIPTS=".git/info/lefthook-remotes/core-actions/scripts"