### PR TITLE
fix: remove hardcoded config paths and skip code blocks in link check

### DIFF
--- a/scripts/common/check-format.sh
+++ b/scripts/common/check-format.sh
@@ -34,7 +34,7 @@ FAIL=0
 for f in $FORMAT_FILES; do
   [ -f "$f" ] || continue
 
-  if ! npx prettier --config configs/common/.prettierrc --ignore-path configs/common/.prettierignore --check "$f" >/dev/null 2>&1; then
+  if ! npx prettier --check "$f" >/dev/null 2>&1; then
     log_error "Not formatted: $f"
     FAIL=1
   fi

--- a/scripts/common/check-markdown-links.sh
+++ b/scripts/common/check-markdown-links.sh
@@ -31,9 +31,14 @@ for file in $MD_FILES; do
 
   FILE_DIR=$(dirname "$file")
 
+  # Strip fenced code blocks before extracting links.
+  # Handles both ``` and ```` (or more) fence markers.
+  STRIPPED_FILE=$(mktemp)
+  sed "/^[[:space:]]*\`\{3,\}/,/^[[:space:]]*\`\{3,\}/d" "$file" >"$STRIPPED_FILE"
+
   # Extract markdown links: [text](url-or-path)
   MATCHES_FILE=$(mktemp)
-  grep -noE '\[([^]]*)\]\(([^)]+)\)' "$file" 2>/dev/null >"$MATCHES_FILE" || true
+  grep -noE '\[([^]]*)\]\(([^)]+)\)' "$STRIPPED_FILE" 2>/dev/null >"$MATCHES_FILE" || true
 
   while IFS= read -r match; do
     LINE_NUM=$(echo "$match" | cut -d: -f1)
@@ -61,7 +66,7 @@ for file in $MD_FILES; do
       FAIL=1
     fi
   done <<<"$(cat "$MATCHES_FILE")"
-  rm -f "$MATCHES_FILE"
+  rm -f "$MATCHES_FILE" "$STRIPPED_FILE"
 done
 
 if [ "$FAIL" -ne 0 ]; then

--- a/tests/scripts/common/check-markdown-links.bats
+++ b/tests/scripts/common/check-markdown-links.bats
@@ -81,3 +81,19 @@ EOF
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
 }
+
+@test "skips links inside fenced code blocks" {
+  cat >docs.md <<'EOF'
+# Template
+
+```markdown
+![Badge](https://example.com/{repo}/badge.svg)
+See [docs](nonexistent/) for details.
+```
+EOF
+  git add docs.md
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Markdown link check passed"* ]]
+}


### PR DESCRIPTION
 ## Summary                                                                                                                                                  
                                                                                                                                                              
  - Remove hardcoded `configs/common/.prettierrc` path from `check-format.sh` — prettier now uses the consumer repo's root config via auto-discovery          
  - Strip fenced code blocks in `check-markdown-links.sh` before scanning for links — fixes false positives on template examples inside code blocks         
  - Add test coverage for code block stripping                                                                                                                
                                                                                                                                                              
  Closes #21