### PR TITLE
fix(license-header): fix --all flag and HTML header stripping in migrate

### DIFF
--- a/scripts/common/license-header.sh
+++ b/scripts/common/license-header.sh
@@ -348,6 +348,7 @@ cmd_migrate() {
     TMPFILE=$(mktemp)
     IN_HEADER=0
     HEADER_DONE=0
+    HTML_COMMENT_CLOSED=0
 
     while IFS= read -r line; do
       if [ "$HEADER_DONE" -eq 1 ]; then
@@ -371,12 +372,35 @@ cmd_migrate() {
         ;;
       esac
 
+      # For HTML, opening <!-- marks the start of the header block
+      if [ "$STYLE" = "html" ] && [ "$IN_HEADER" -eq 0 ]; then
+        case "$line" in
+        '<!--')
+          IN_HEADER=1
+          continue
+          ;;
+        esac
+      fi
+
       if [ "$IN_HEADER" -eq 1 ]; then
         IS_COMMENT=0
         case "$STYLE" in
         hash) case "$line" in '#'* | '') IS_COMMENT=1 ;; esac ;;
         slash) case "$line" in '//'* | '') IS_COMMENT=1 ;; esac ;;
-        html) case "$line" in '<!--'* | '-->'* | '') IS_COMMENT=1 ;; esac ;;
+        html)
+          case "$line" in
+          '-->'*)
+            IS_COMMENT=1
+            HTML_COMMENT_CLOSED=1
+            ;;
+          '') IS_COMMENT=1 ;;
+          *)
+            if [ "$HTML_COMMENT_CLOSED" -eq 0 ]; then
+              IS_COMMENT=1
+            fi
+            ;;
+          esac
+          ;;
         esac
 
         if [ "$IS_COMMENT" -eq 1 ]; then


### PR DESCRIPTION
# Summary                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                     
  - `--all` and `--staged` shared the same branch in `resolve_files`, both
    echoing `$CHECK_FILES`. Outside a hook context (CI, manual runs) `$CHECK_FILES`
    is empty, causing `--all` to silently process 0 files. Split into separate
    branches — `--all` now calls `get_all_source_files` via `git ls-files`,
    `--staged` retains `$CHECK_FILES` for hook context.

  - `migrate` header stripping was broken for HTML files. The opening `<!--`
    arrives before the Copyright line, so it was written to the file before
    `IN_HEADER` was ever set. Content lines inside the block were not recognised
    as comments, causing premature `HEADER_DONE` and leaving `-->` in the file.
    Fixed by detecting `<!--` as the header start and tracking
    `HTML_COMMENT_CLOSED` to correctly skip all lines until the block closes.

  - Updated usage comment to reflect `--all` is valid for the `check` command.