### PR TITLE
fix(check-naming): allow PascalCase css/scss with component sibling

### DIFF
--- a/scripts/common/check-naming.sh
+++ b/scripts/common/check-naming.sh
@@ -75,6 +75,20 @@ while IFS= read -r FILE; do
   *.sh) continue ;;
   esac
 
+  # Allow PascalCase .css/.scss when a sibling component file exists in the same directory
+  case "$BASE" in
+  *.css | *.scss)
+    NAME="${BASE%.*}"
+    if echo "$NAME" | grep -qE '^[A-Z][a-zA-Z0-9]*$'; then
+      SIBLING_FOUND=0
+      for EXT in js jsx ts tsx; do
+        [ -f "$DIR/$NAME.$EXT" ] && SIBLING_FOUND=1 && break
+      done
+      [ "$SIBLING_FOUND" -eq 1 ] && continue
+    fi
+    ;;
+  esac
+
   # Allow no-extension uppercase files (LICENSE, CODEOWNERS)
   echo "$BASE" | grep -qE '^[A-Z][A-Z0-9_]*$' && continue
 

--- a/tests/scripts/common/check-naming.bats
+++ b/tests/scripts/common/check-naming.bats
@@ -155,6 +155,87 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+# --- PascalCase CSS/SCSS with sibling component ---
+
+@test "passes when PascalCase .css has sibling .jsx" {
+  mkdir -p src
+  echo "" >src/App.jsx
+  echo "" >src/App.css
+  git add src/App.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when PascalCase .css has sibling .tsx" {
+  mkdir -p src
+  echo "" >src/Button.tsx
+  echo "" >src/Button.css
+  git add src/Button.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when PascalCase .css has sibling .js" {
+  mkdir -p src
+  echo "" >src/App.js
+  echo "" >src/App.css
+  git add src/App.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when PascalCase .css has sibling .ts" {
+  mkdir -p src
+  echo "" >src/App.ts
+  echo "" >src/App.css
+  git add src/App.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when PascalCase .scss has sibling .jsx" {
+  mkdir -p src
+  echo "" >src/App.jsx
+  echo "" >src/App.scss
+  git add src/App.scss
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "fails when PascalCase .css has no sibling component" {
+  mkdir -p src
+  echo "" >src/App.css
+  git add src/App.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid filename"* ]]
+}
+
+@test "fails when PascalCase .scss has no sibling component" {
+  mkdir -p src
+  echo "" >src/App.scss
+  git add src/App.scss
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Invalid filename"* ]]
+}
+
+@test "passes with kebab-case .css without sibling" {
+  mkdir -p src
+  echo "" >src/app.css
+  git add src/app.css
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
 # --- Invalid filenames ---
 
 @test "fails on PascalCase non-language file" {


### PR DESCRIPTION
  ## Summary

  - The common `check-naming` script enforced kebab-case for all files
    including `.css` and `.scss`. This blocked the React convention of
    co-locating a component's stylesheet using the same PascalCase name
    (e.g. `App.css` alongside `App.jsx`), which is how Vite, CRA, and
    Next.js scaffold by default.

  - Added an exception: a PascalCase `.css` or `.scss` file is allowed
    only when a same-directory sibling component file exists on disk with
    a matching name and a `.js`, `.jsx`, `.ts`, or `.tsx` extension.
    Without the sibling, the file still fails the kebab-case check.

  - Added 8 test cases covering all sibling extensions (js, jsx, ts, tsx),
    scss variant, kebab-case css (no sibling needed), and both fail cases
    (PascalCase css/scss with no sibling).