### PR TITLE
fix(update-major-tag): skip update when version is not a stable release

### DIFF
--- a/.github/workflows/tpl-release.yml
+++ b/.github/workflows/tpl-release.yml
@@ -34,6 +34,15 @@ on:
         required: false
         default: true
 
+      release-pattern:
+        description: >
+          Regex pattern to identify a stable production release version.
+          Only versions matching this pattern will trigger a major tag update.
+          Defaults to strict semver (X.Y.Z) with no pre-release suffix.
+        type: string
+        required: false
+        default: '^[0-9]+\.[0-9]+\.[0-9]+$'
+
       core-actions-ref:
         description: Git ref for core-actions checkout (tag, branch, or SHA)
         type: string
@@ -132,4 +141,5 @@ jobs:
         with:
           version: ${{ steps.release.outputs.new_release_version }}
           enabled: ${{ inputs.update-major-tag }}
+          release-pattern: ${{ inputs.release-pattern }}
           token: ${{ steps.app-token.outputs.token }}

--- a/actions/release/update-major-tag/action.yml
+++ b/actions/release/update-major-tag/action.yml
@@ -14,6 +14,14 @@ inputs:
     required: false
     default: 'true'
 
+  release-pattern:
+    description: >
+      Regex pattern to identify a stable production release version.
+      Only versions matching this pattern will trigger a major tag update.
+      Defaults to strict semver (X.Y.Z) with no pre-release suffix.
+    required: false
+    default: '^[0-9]+\.[0-9]+\.[0-9]+$'
+
   token:
     description: GitHub App token for pushing tags
     required: true
@@ -36,12 +44,23 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         ENABLED: ${{ inputs.enabled }}
+        RELEASE_PATTERN: ${{ inputs.release-pattern }}
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
         if [ "$ENABLED" != "true" ]; then
           echo "Major tag update disabled — skipping."
           echo "action=skipped" >> "$GITHUB_OUTPUT"
           echo "major_tag=" >> "$GITHUB_OUTPUT"
+          echo "SKIP_REASON=disabled" >> "$GITHUB_ENV"
+          exit 0
+        fi
+
+        # Only update major tag for stable production releases
+        if ! echo "$VERSION" | grep -qE "$RELEASE_PATTERN"; then
+          echo "Version '${VERSION}' not identified as a stable release — skipping major tag update."
+          echo "action=skipped" >> "$GITHUB_OUTPUT"
+          echo "major_tag=" >> "$GITHUB_OUTPUT"
+          echo "SKIP_REASON=not-stable" >> "$GITHUB_ENV"
           exit 0
         fi
 
@@ -88,6 +107,10 @@ runs:
             echo "| **Tag** | \`${MAJOR_TAG}\` → \`v${VERSION#v}\` |" >> "$GITHUB_STEP_SUMMARY"
             ;;
           skipped)
-            echo "| **Action** | Skipped (disabled) |" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$SKIP_REASON" = "not-stable" ]; then
+              echo "| **Action** | Skipped (not identified as stable release) |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| **Action** | Skipped (disabled) |" >> "$GITHUB_STEP_SUMMARY"
+            fi
             ;;
         esac


### PR DESCRIPTION
## Problem                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  `update-major-tag` ran on every published release including pre-releases
  (e.g. `1.2.0-beta.1`), which force-moved the stable `v1` tag to a beta
  version — silently breaking consumers pinned to `@v1`.

  This also caused a secondary issue: if `v1` was manually deleted and a
  pre-release ran before the next production release, the production release
  would report the tag as `updated` instead of `created`.

  ## Changes

  - Added `release-pattern` input (default: `^[0-9]+\.[0-9]+\.[0-9]+$`) to
    identify stable production releases
  - Versions not matching the pattern are skipped with a clear log message
    and step summary reason ("not identified as stable release")
  - Exposed `release-pattern` as a pass-through input on `tpl-release.yml`
    for consumers with non-standard versioning schemes
  - Existing `enabled` input is unchanged

  ## Behaviour

  | Version | Pattern (default) | Result |
  |---|---|---|
  | `1.2.0` | `^[0-9]+\.[0-9]+\.[0-9]+$` | Updates `v1` |
  | `1.2.0-beta.1` | `^[0-9]+\.[0-9]+\.[0-9]+$` | Skipped (not identified as stable release) |
  | `2.0.0` | `^[0-9]+\.[0-9]+\.[0-9]+$` | Creates `v2` |

  Closes #57