### PR TITLE
fix(validate-commit-msg): strip PR number suffix before length check

### DIFF
--- a/scripts/common/check-pr-title.sh
+++ b/scripts/common/check-pr-title.sh
@@ -38,7 +38,8 @@ if ! echo "$PR_TITLE" | grep -qE "$PATTERN"; then
   exit 1
 fi
 
-LENGTH=$(echo "$PR_TITLE" | wc -c | tr -d ' ')
+NORMALIZED=$(strip_pr_suffix "$PR_TITLE")
+LENGTH=$(echo "$NORMALIZED" | wc -c | tr -d ' ')
 LENGTH=$((LENGTH - 1))
 if [ "$LENGTH" -gt "$MAX_LENGTH" ]; then
   log_error "PR title is $LENGTH characters (max $MAX_LENGTH)."

--- a/scripts/common/utils.sh
+++ b/scripts/common/utils.sh
@@ -103,6 +103,13 @@ is_skippable_file() {
   return 1
 }
 
+# Strips the GitHub-appended PR number suffix from a commit/title string.
+# GitHub appends " (#N)" during squash merge — this should not count toward length limits.
+# Usage: strip_pr_suffix "fix(scope): some message (#42)"
+strip_pr_suffix() {
+  echo "${1% (#[0-9]*)}"
+}
+
 # Returns file content: full file in "all" mode, only added diff lines otherwise.
 # Usage: get_file_content "file.js" "$CHECK_MODE"
 get_file_content() {

--- a/scripts/common/validate-commit-msg.sh
+++ b/scripts/common/validate-commit-msg.sh
@@ -35,7 +35,8 @@ validate_message() {
     return 1
   fi
 
-  LENGTH=$(echo "$FIRST_LINE" | wc -c | tr -d ' ')
+  NORMALIZED=$(strip_pr_suffix "$FIRST_LINE")
+  LENGTH=$(echo "$NORMALIZED" | wc -c | tr -d ' ')
   LENGTH=$((LENGTH - 1))
   if [ "$LENGTH" -gt "$MAX_LENGTH" ]; then
     log_error "Commit message first line is $LENGTH characters (max $MAX_LENGTH).${CONTEXT:+ ($CONTEXT)}"

--- a/tests/scripts/common/check-pr-title.bats
+++ b/tests/scripts/common/check-pr-title.bats
@@ -55,6 +55,25 @@ teardown() {
   [[ "$output" == *"characters (max 72)"* ]]
 }
 
+@test "accepts title with PR number suffix within limit after stripping" {
+  # 71 chars + " (#58)" = 77 chars raw — mirrors the real CI failure case
+  run env PR_TITLE="fix(update-major-tag): skip update when version is not a stable release (#58)" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts title at exactly 72 chars with PR number suffix" {
+  # "fix(scope): " (12) + 60 a's = 72 chars, plus " (#1)" suffix
+  run env PR_TITLE="fix(scope): aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (#1)" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects title exceeding 72 chars even after stripping PR number suffix" {
+  # 73 chars + " (#1)" — stripping still leaves 73 chars which exceeds limit
+  run env PR_TITLE="feat: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (#1)" bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"characters (max 72)"* ]]
+}
+
 @test "rejects description starting with uppercase" {
   run env PR_TITLE="feat: Add login page" bash "$SCRIPT"
   [ "$status" -eq 1 ]

--- a/tests/scripts/common/utils.bats
+++ b/tests/scripts/common/utils.bats
@@ -245,6 +245,32 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+# --- strip_pr_suffix ---
+
+@test "strip_pr_suffix removes single-digit PR number suffix" {
+  run strip_pr_suffix "fix(scope): some message (#1)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix(scope): some message" ]
+}
+
+@test "strip_pr_suffix removes multi-digit PR number suffix" {
+  run strip_pr_suffix "fix(scope): some message (#9999)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix(scope): some message" ]
+}
+
+@test "strip_pr_suffix is a no-op when no suffix present" {
+  run strip_pr_suffix "fix(scope): some message"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix(scope): some message" ]
+}
+
+@test "strip_pr_suffix does not strip PR reference in the middle of message" {
+  run strip_pr_suffix "fix(scope): some (#42) message"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix(scope): some (#42) message" ]
+}
+
 # --- get_file_content ---
 
 @test "get_file_content returns full file in all mode" {

--- a/tests/scripts/common/validate-commit-msg.bats
+++ b/tests/scripts/common/validate-commit-msg.bats
@@ -62,6 +62,28 @@ teardown() {
   [[ "$output" == *"characters (max 72)"* ]]
 }
 
+@test "accepts squash commit with PR number suffix within limit after stripping" {
+  # 71 chars + " (#58)" = 77 chars raw — mirrors the real CI failure case
+  echo "fix(update-major-tag): skip update when version is not a stable release (#58)" >"$MSG_FILE"
+  run bash "$SCRIPT" "$MSG_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "accepts message at exactly 72 chars with PR number suffix" {
+  # "fix(scope): " (12) + 60 a's = 72 chars, plus " (#1)" suffix
+  echo "fix(scope): aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (#1)" >"$MSG_FILE"
+  run bash "$SCRIPT" "$MSG_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "rejects message exceeding 72 chars even after stripping PR number suffix" {
+  # 73 chars + " (#1)" — stripping still leaves 73 chars which exceeds limit
+  echo "feat: this is a long commit message that is seventy three characters long (#1)" >"$MSG_FILE"
+  run bash "$SCRIPT" "$MSG_FILE"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"characters (max 72)"* ]]
+}
+
 @test "rejects description starting with uppercase" {
   echo "feat: Add login page" >"$MSG_FILE"
   run bash "$SCRIPT" "$MSG_FILE"


### PR DESCRIPTION
## Problem                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  GitHub appends ` (#N)` to the PR title when squash merging, forming the
  commit message. The length validator checked the full string including
  the suffix, causing valid commits to fail the 72-character limit on
  subsequent PRs.

  Example:
  - PR title (71 chars) ✅ passes PR title check
  - Squash commit `<title> (#58)` (77 chars) ❌ fails commit message check

  ## Changes

  - Added `strip_pr_suffix` to `utils.sh` — strips ` (#N)` from the right
    using parameter expansion (no subprocess)
  - `validate-commit-msg.sh` — strips suffix before length check
  - `check-pr-title.sh` — strips suffix before length check for consistency
  - Tests added to all three files covering strip, pass, and reject cases

  Closes #60