### PR TITLE
chore(configs): use verified-commit plugin in shared node releaserc

### DIFF
--- a/configs/node/.releaserc.json
+++ b/configs/node/.releaserc.json
@@ -50,7 +50,7 @@
       }
     ],
     [
-      "@semantic-release/git",
+      ".git/modules/core-actions/src/plugins/verified-commit.js",
       {
         "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
# Problem                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  `configs/node/.releaserc.json` used `@semantic-release/git` which creates                                                                                                                                         
  release commits via local git commands. GitHub cannot verify these, so                                                                                                                                            
  release commits in consumer repos appeared as unverified.                                                                                                                                                         
                                                                                                                                                                                                                    
  Core-actions' own `.releaserc.json` already uses `verified-commit.js`
  which creates commits via the GitHub Git Database API — GitHub marks                                                                                                                                              
  these as verified. The shared config was never updated to match.                                                                                                                                                  
                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  - Replaced `@semantic-release/git` with                                                                                                                                                                           
    `.git/modules/core-actions/src/plugins/verified-commit.js` in                                                                                                                                                   
    `configs/node/.releaserc.json`                                                                                                                                                                                  

  The plugin is always available at that path since `tpl-release.yml`                                                                                                                                               
  checks out core-actions at `.git/modules/core-actions`.                                                                                                                                                           
                                                                                                                                                                                                                    
  Closes #63