### PR TITLE
fix(tpl-release): install core-actions deps for verified-commit plugin

### DIFF
--- a/.github/workflows/tpl-release.yml
+++ b/.github/workflows/tpl-release.yml
@@ -119,6 +119,10 @@ jobs:
           path: .git/modules/core-actions
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Install core-actions dependencies
+        run: npm ci
+        working-directory: .git/modules/core-actions
+
       - name: Configure git identity
         env:
           APP_ID: ${{ secrets.APP_ID }}


### PR DESCRIPTION
## Problem                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  `verified-commit.js` dynamically imports `@octokit/rest` at runtime.                                                                                                                                              
  When the release workflow runs, `@octokit/rest` is not in the consumer's
  `node_modules` so Node.js cannot resolve it and the release fails.                                                                                                                                                
                                                                                                                                                                                                                    
  Installing it in the `semantic-release` action is wrong — the pipeline                                                                                                                                            
  does not know whether the consumer uses `verified-commit.js`, so it                                                                                                                                               
  would install an unused dependency on every release.                                                                                                                                                              
                                                                                                                                                                                                                    
  ## Fix
                                                                                                                                                                                                                    
  `@octokit/rest` is already a dependency in core-actions `package.json`                                                                                                                                            
  but `npm ci` was never run for the core-actions checkout at                                                                                                                                                       
  `.git/modules/core-actions`. Added an `npm ci` step in `tpl-release.yml`                                                                                                                                          
  after the core-actions checkout. Node.js module resolution from                                                                                                                                                   
  `.git/modules/core-actions/src/plugins/verified-commit.js` then finds                                                                                                                                             
  `@octokit/rest` in `.git/modules/core-actions/node_modules` — no                                                                                                                                                  
  consumer needs to add it to their `package.json`.                                                                                                                                                                 
                                                                                                                                                                                                                    
  Closes #67