### PR TITLE
feat(coverage): add summaryFile field to COVERAGE_CONFIG_NODE

### DIFF
--- a/docs/hooks-config.md
+++ b/docs/hooks-config.md
@@ -71,10 +71,11 @@ Node coverage is checked per-metric (lines, statements, functions, branches). Th
 COVERAGE_CONFIG_NODE={"floor":{"lines":80,"statements":80,"functions":75,"branches":70},"delta":2}
 ```
 
-| Field   | Type        | Description                                                               |
-| ------- | ----------- | ------------------------------------------------------------------------- |
-| `floor` | JSON object | Per-metric minimum percentage. Fails if any metric drops below its floor. |
-| `delta` | number      | Maximum allowed drop from baseline for any single metric.                 |
+| Field         | Type        | Description                                                                                  |
+| ------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `floor`       | JSON object | Per-metric minimum percentage. Fails if any metric drops below its floor.                    |
+| `delta`       | number      | Maximum allowed drop from baseline for any single metric.                                    |
+| `summaryFile` | string      | Path to the Istanbul JSON summary file. Defaults to `${COVERAGE_DIR}/coverage-summary.json`. |
 
 If `COVERAGE_CONFIG_NODE` is not set, the legacy `COVERAGE_FLOOR` and `COVERAGE_MAX_DROP` values are used and the same floor applies to all four metrics.
 

--- a/scripts/node/coverage.sh
+++ b/scripts/node/coverage.sh
@@ -21,11 +21,13 @@ if [ "$STATUS" -ne 0 ]; then
   exit 1
 fi
 
-SUMMARY_FILE="${COVERAGE_DIR}/coverage-summary.json"
+_SUMMARY_FILE=$(echo "${COVERAGE_CONFIG_NODE:-}" | jq -r '.summaryFile // empty' 2>/dev/null)
+SUMMARY_FILE="${_SUMMARY_FILE:-${COVERAGE_DIR}/coverage-summary.json}"
 
 if [ ! -f "$SUMMARY_FILE" ]; then
   log_error "Coverage summary not found at ${SUMMARY_FILE}."
-  log_info "Ensure '${COVERAGE_SCRIPT}' generates a json-summary report."
+  log_info "Ensure '${COVERAGE_SCRIPT}' generates a json-summary report (Istanbul format)."
+  log_info "Override path via summaryFile in COVERAGE_CONFIG_NODE if needed."
   exit 1
 fi
 

--- a/tests/scripts/node/coverage.bats
+++ b/tests/scripts/node/coverage.bats
@@ -182,6 +182,28 @@ EOF
   [[ "$output" == *"+1.00% from"* ]]
 }
 
+@test "uses custom summaryFile from COVERAGE_CONFIG_NODE when set" {
+  create_mock "npm" 'exit 0'
+  mkdir -p custom-reports
+  cat >custom-reports/summary.json <<EOF
+{"total":{"lines":{"pct":90},"statements":{"pct":90},"functions":{"pct":90},"branches":{"pct":90}}}
+EOF
+
+  export COVERAGE_CONFIG_NODE='{"floor":{"lines":80,"statements":80,"functions":80,"branches":80},"delta":0.05,"summaryFile":"custom-reports/summary.json"}'
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"lines: 90%"* ]]
+}
+
+@test "fails when custom summaryFile does not exist" {
+  create_mock "npm" 'exit 0'
+
+  export COVERAGE_CONFIG_NODE='{"floor":{"lines":80,"statements":80,"functions":80,"branches":80},"delta":0.05,"summaryFile":"no-such-dir/summary.json"}'
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Coverage summary not found"* ]]
+}
+
 @test "warns and skips delta when baseline is a plain number" {
   create_mock "npm" 'exit 0'
   create_summary 96 96 96 96


### PR DESCRIPTION
## Summary

  Closes #70

  - Adds `summaryFile` as an optional field inside `COVERAGE_CONFIG_NODE`
  - When set, `scripts/node/coverage.sh` uses that path instead of the
    hardcoded `${COVERAGE_DIR}/coverage-summary.json`
  - Falls back to the existing default when `summaryFile` is omitted —
    no breaking change for current consumers
  - Documents the new field in `docs/hooks-config.md`

  ## Why inside COVERAGE_CONFIG_NODE

  The summary file is an Istanbul-format artifact specific to the Node
  runner. Placing `summaryFile` inside the existing `COVERAGE_CONFIG_NODE`
  object keeps all Node coverage config in one place and avoids adding
  another top-level `.hooks-config` key.

  ## Example

  \`\`\`bash
  COVERAGE_CONFIG_NODE={"floor":{"lines":80,"statements":80,"functions":75,"branches":70},"delta":0.05,"summaryFile":"reports/coverage-summary.json"}
  \`\`\`

  ## Test plan

  - [x] `uses custom summaryFile from COVERAGE_CONFIG_NODE when set` — passes with custom path
  - [x] `fails when custom summaryFile does not exist` — correct error message shown
  - [x] All 17 existing node coverage tests still pass