### PR TITLE
fix(hooks): include root-level .md files in check-markdown-lint glob

### DIFF
--- a/lefthook/common.yml
+++ b/lefthook/common.yml
@@ -42,7 +42,7 @@ pre-commit:
                 - name: check-format
                   run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-format.sh
                 - name: check-markdown-lint
-                  glob: '**/*.md'
+                  glob: '*.md,**/*.md'
                   run: markdownlint-cli2 {staged_files}
                 - name: check-spelling
                   run: bash ${HOOKS_SCRIPTS:-scripts}/common/check-spelling.sh


### PR DESCRIPTION
 ## Summary                                                                  
  - Changes `check-markdown-lint` glob from `**/*.md` to `*.md,**/*.md` in `lefthook/common.yml`        
  - `**/*.md` requires at least one directory separator, silently skipping root-level files like        
  `README.md` and `CHANGELOG.md` when staged                                                            
  - The added `*.md` pattern covers root-level files; `**/*.md` continues to cover all nested files     

Closes #84