### PR TITLE
fix(check-paths): add CHECK_PATHS_SKIP_FILES config to skip Docker paths

### DIFF
--- a/.hooks-config
+++ b/.hooks-config
@@ -17,3 +17,4 @@ COVERAGE_TAG=js
 # JSON values must use compact format (no spaces) and must not contain '=' characters.
 # See docs/hooks-config.md for migration guidance from plain number baseline to JSON format.
 COVERAGE_CONFIG_NODE={"floor":{"lines":100,"statements":100,"functions":100,"branches":100},"delta":0.05}
+CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile","docker-compose.yml","docker-compose.*.yml"]

--- a/docs/hooks-config.md
+++ b/docs/hooks-config.md
@@ -37,6 +37,18 @@ COVERAGE_CONFIG_NODE={"floor":{"lines":80,"statements":80,"functions":75,"branch
 
 ---
 
+## Path Check Settings
+
+| Key                      | Default | Description                                                                                                                                   |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CHECK_PATHS_SKIP_FILES` | `[]`    | JSON array of filename patterns to exclude from the hardcoded-path check. Supports shell glob patterns (e.g. `Dockerfile.*`, `*.dockerfile`). |
+
+```bash
+CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile","docker-compose.yml","docker-compose.*.yml"]
+```
+
+---
+
 ## Coverage Settings (Legacy)
 
 These apply to shell, go, and python runners. Node uses `COVERAGE_CONFIG_NODE` instead.
@@ -140,6 +152,7 @@ MAX_COMMIT_MSG_LENGTH=72
 PROTECTED_BRANCHES=main master pre-main
 LINK_CHECK_TIMEOUT=5
 CHECK_MODE=staged
+CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile","docker-compose.yml","docker-compose.*.yml"]
 # Legacy floor used by shell runner
 COVERAGE_FLOOR=70
 COVERAGE_MAX_DROP=0.05

--- a/scripts/common/check-paths.sh
+++ b/scripts/common/check-paths.sh
@@ -27,6 +27,19 @@ for f in $CHECK_FILES; do
   # Skip binary-ish files
   is_skippable_file "$f" && continue
 
+  # Skip files excluded via CHECK_PATHS_SKIP_FILES config
+  if [ -n "$CHECK_PATHS_SKIP_FILES" ] && command -v jq >/dev/null 2>&1; then
+    _skip=0
+    while IFS= read -r _pattern; do
+      _re=$(printf '%s' "$_pattern" | sed 's/\./[.]/g; s/\*/.*/g; s/?/./g')
+      if echo "$f" | grep -qE "^${_re}$"; then
+        _skip=1
+        break
+      fi
+    done <<<"$(echo "$CHECK_PATHS_SKIP_FILES" | jq -r '.[]' 2>/dev/null)"
+    [ "$_skip" -eq 1 ] && continue
+  fi
+
   CONTENT=$(get_file_content "$f" "$CHECK_MODE")
 
   [ -z "$CONTENT" ] && continue

--- a/scripts/common/config.sh
+++ b/scripts/common/config.sh
@@ -35,6 +35,7 @@ COVERAGE_CONFIG_SHELL="${COVERAGE_CONFIG_SHELL:-}"
 COVERAGE_CONFIG_GO="${COVERAGE_CONFIG_GO:-}"
 COVERAGE_CONFIG_PYTHON="${COVERAGE_CONFIG_PYTHON:-}"
 CHECK_MODE="${CHECK_MODE:-staged}"
+CHECK_PATHS_SKIP_FILES="${CHECK_PATHS_SKIP_FILES:-[]}"
 
 # ── Override from .hooks-config ─────────────────────────────────────
 
@@ -63,6 +64,7 @@ if [ -f ".hooks-config" ]; then
     COVERAGE_CONFIG_GO) COVERAGE_CONFIG_GO="$value" ;;
     COVERAGE_CONFIG_PYTHON) COVERAGE_CONFIG_PYTHON="$value" ;;
     CHECK_MODE) CHECK_MODE="$value" ;;
+    CHECK_PATHS_SKIP_FILES) CHECK_PATHS_SKIP_FILES="$value" ;;
     esac
   done <<<"$(cat .hooks-config)"
 fi

--- a/tests/scripts/common/check-paths.bats
+++ b/tests/scripts/common/check-paths.bats
@@ -93,6 +93,52 @@ EOF
   [[ "$output" == *"Hardcoded Windows path"* ]]
 }
 
+@test "passes when file matches CHECK_PATHS_SKIP_FILES pattern" {
+  # Build path dynamically to avoid triggering the hook on this file
+  printf 'RUN rm -rf %s\n' "/va""r/lib/apt/lists/*" >Dockerfile
+  git add Dockerfile
+
+  echo 'CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile","docker-compose.yml","docker-compose.*.yml"]' >.hooks-config
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Path check passed"* ]]
+}
+
+@test "still flags absolute paths in files not matching CHECK_PATHS_SKIP_FILES" {
+  # Build path dynamically to avoid triggering the hook on this file
+  printf 'RUN rm -rf %s\n' "/va""r/lib/apt/lists/*" >Dockerfile
+  git add Dockerfile
+
+  echo 'CHECK_PATHS_SKIP_FILES=["*.txt"]' >.hooks-config
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Hardcoded UNIX path"* ]]
+}
+
+@test "iterates all patterns when none match and still flags the file" {
+  printf 'const dir = "%s";\n' "/Us""ers/john/projects/app" >app.js
+  git add app.js
+
+  echo 'CHECK_PATHS_SKIP_FILES=["Dockerfile","docker-compose.yml","*.txt"]' >.hooks-config
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Hardcoded UNIX path"* ]]
+}
+
+@test "CHECK_PATHS_SKIP_FILES empty array skips no files" {
+  printf 'const dir = "%s";\n' "/Us""ers/john/projects/app" >app.js
+  git add app.js
+
+  echo 'CHECK_PATHS_SKIP_FILES=[]' >.hooks-config
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Hardcoded UNIX path"* ]]
+}
+
 @test "detects hardcoded paths in all mode" {
   printf 'const dir = "%s";\n' "/Us""ers/john/projects/app" >app.js
   git add app.js

--- a/tests/scripts/common/config.bats
+++ b/tests/scripts/common/config.bats
@@ -185,6 +185,19 @@ EOF
 
 # ── COVERAGE_CONFIG_* keys ────────────────────────────────────────
 
+@test "config defaults CHECK_PATHS_SKIP_FILES to empty array" {
+  [ "$(get_config_var CHECK_PATHS_SKIP_FILES)" = "[]" ]
+}
+
+@test "config reads CHECK_PATHS_SKIP_FILES from .hooks-config" {
+  cat >.hooks-config <<'EOF'
+CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile"]
+EOF
+
+  result="$(get_config_var CHECK_PATHS_SKIP_FILES)"
+  [ "$result" = '["Dockerfile","Dockerfile.*","*.dockerfile"]' ]
+}
+
 @test "config defaults COVERAGE_CONFIG_* to empty string" {
   [ "$(get_config_var COVERAGE_CONFIG_NODE)" = "" ]
   [ "$(get_config_var COVERAGE_CONFIG_SHELL)" = "" ]


### PR DESCRIPTION
## Summary

  - Adds `CHECK_PATHS_SKIP_FILES` to `.hooks-config` — a JSON array of filename glob patterns that `check-paths.sh` will skip entirely
  - Fixes false positives on Docker container paths in `Dockerfile` and `docker-compose.yml`, which are inherently absolute and cannot be relative
  - Default is `[]` (no files skipped unless configured); Docker patterns are set in the repo's own `.hooks-config` as an example
  - Parses the JSON array with `jq`, consistent with the `COVERAGE_CONFIG_*` pattern already in use

Closes #85