### PR TITLE
fix(coverage): isolate baseline tag per runner config (#89)

### DIFF
--- a/.hooks-config
+++ b/.hooks-config
@@ -16,5 +16,6 @@ COVERAGE_TAG=js
 # Per-runner coverage config: floor (per-metric JSON for node, plain number for others) + delta.
 # JSON values must use compact format (no spaces) and must not contain '=' characters.
 # See docs/hooks-config.md for migration guidance from plain number baseline to JSON format.
-COVERAGE_CONFIG_NODE={"floor":{"lines":100,"statements":100,"functions":100,"branches":100},"delta":0.05}
+COVERAGE_CONFIG_NODE={"floor":{"lines":100,"statements":100,"functions":100,"branches":100},"delta":0.05,"tag":"js"}
+COVERAGE_CONFIG_SHELL={"floor":80,"delta":0.05,"tag":"shell"}
 CHECK_PATHS_SKIP_FILES=["Dockerfile","Dockerfile.*","*.dockerfile","docker-compose.yml","docker-compose.*.yml"]

--- a/docs/hooks-config.md
+++ b/docs/hooks-config.md
@@ -87,19 +87,28 @@ COVERAGE_CONFIG_NODE={"floor":{"lines":80,"statements":80,"functions":75,"branch
 | ------------- | ----------- | -------------------------------------------------------------------------------------------- |
 | `floor`       | JSON object | Per-metric minimum percentage. Fails if any metric drops below its floor.                    |
 | `delta`       | number      | Maximum allowed drop from baseline for any single metric.                                    |
+| `tag`         | string      | Baseline tag to look up in `.coverage-baseline`. Overrides the legacy `COVERAGE_TAG`.        |
 | `summaryFile` | string      | Path to the Istanbul JSON summary file. Defaults to `${COVERAGE_DIR}/coverage-summary.json`. |
 
 If `COVERAGE_CONFIG_NODE` is not set, the legacy `COVERAGE_FLOOR` and `COVERAGE_MAX_DROP` values are used and the same floor applies to all four metrics.
 
 ### Shell / Go / Python
 
-For these runners, `floor` is a plain number that applies to the single overall coverage percentage.
+For these runners, `floor` is a plain number that applies to the single overall coverage percentage. Each runner reads only its own config — `COVERAGE_CONFIG_SHELL` is never used by the Go or Python runner.
 
 ```bash
-COVERAGE_CONFIG_SHELL={"floor":70,"delta":5}
-COVERAGE_CONFIG_GO={"floor":80,"delta":2}
-COVERAGE_CONFIG_PYTHON={"floor":80,"delta":2}
+COVERAGE_CONFIG_SHELL={"floor":70,"delta":5,"tag":"shell"}
+COVERAGE_CONFIG_GO={"floor":80,"delta":2,"tag":"go"}
+COVERAGE_CONFIG_PYTHON={"floor":80,"delta":2,"tag":"python"}
 ```
+
+| Field   | Type   | Description                                                                           |
+| ------- | ------ | ------------------------------------------------------------------------------------- |
+| `floor` | number | Minimum coverage percentage. Fails if coverage drops below this.                      |
+| `delta` | number | Maximum allowed drop from baseline.                                                   |
+| `tag`   | string | Baseline tag to look up in `.coverage-baseline`. Overrides the legacy `COVERAGE_TAG`. |
+
+If a runner-specific config is not set, the runner falls back to the legacy `COVERAGE_FLOOR`, `COVERAGE_MAX_DROP`, and `COVERAGE_TAG` globals.
 
 ---
 

--- a/scripts/common/check-coverage.sh
+++ b/scripts/common/check-coverage.sh
@@ -135,6 +135,15 @@ fi
 # ── Number mode (shell, go, python — single percent) ─────────────────
 
 PERCENT="$INPUT"
+RUNNER_CONFIG="${3:-}"
+
+# Runner-specific config overrides legacy floor/delta — honours COVERAGE_CONFIG_SHELL/GO/PYTHON
+if [ -n "$RUNNER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
+  _rf=$(echo "$RUNNER_CONFIG" | jq -r '.floor // empty' 2>/dev/null)
+  _rd=$(echo "$RUNNER_CONFIG" | jq -r '.delta // empty' 2>/dev/null)
+  [ -n "$_rf" ] && COVERAGE_FLOOR="$_rf"
+  [ -n "$_rd" ] && COVERAGE_MAX_DROP="$_rd"
+fi
 
 # Floor check — absolute minimum
 BELOW_FLOOR=$(awk -v p="$PERCENT" -v f="$COVERAGE_FLOOR" 'BEGIN { print (p < f) ? 1 : 0 }')

--- a/scripts/go/coverage.sh
+++ b/scripts/go/coverage.sh
@@ -7,9 +7,7 @@
 
 # Runs Go tests with coverage and checks against baseline.
 
-. "$(dirname "$0")/../common/utils.sh"
-
-COVERAGE_DIR="${COVERAGE_DIR:-coverage}"
+. "$(dirname "$0")/../common/config.sh"
 
 log_info "Running Go tests with coverage..."
 
@@ -34,4 +32,8 @@ fi
 
 log_info "Coverage: ${PERCENT}%"
 log_info "Report: ${COVERAGE_DIR}/index.html"
-bash "$(dirname "$0")/../common/check-coverage.sh" "$PERCENT"
+_tag=""
+if command -v jq >/dev/null 2>&1; then
+  _tag=$(echo "${COVERAGE_CONFIG_GO:-}" | jq -r '.tag // empty' 2>/dev/null)
+fi
+bash "$(dirname "$0")/../common/check-coverage.sh" "$PERCENT" "${_tag:-${COVERAGE_TAG:-}}" "${COVERAGE_CONFIG_GO:-}"

--- a/scripts/node/coverage.sh
+++ b/scripts/node/coverage.sh
@@ -40,4 +40,5 @@ if [ -z "$METRICS" ] || ! echo "$METRICS" | jq -e '[.lines,.statements,.function
 fi
 
 log_info "Report: ${COVERAGE_DIR}/index.html"
-bash "$(dirname "$0")/../common/check-coverage.sh" "$METRICS" "${COVERAGE_TAG:-}"
+_tag=$(echo "${COVERAGE_CONFIG_NODE:-}" | jq -r '.tag // empty' 2>/dev/null)
+bash "$(dirname "$0")/../common/check-coverage.sh" "$METRICS" "${_tag:-${COVERAGE_TAG:-}}"

--- a/scripts/python/coverage.sh
+++ b/scripts/python/coverage.sh
@@ -8,9 +8,7 @@
 # Runs Python tests with coverage and checks against baseline.
 # Expects: pytest with pytest-cov installed.
 
-. "$(dirname "$0")/../common/utils.sh"
-
-COVERAGE_DIR="${COVERAGE_DIR:-coverage}"
+. "$(dirname "$0")/../common/config.sh"
 
 log_info "Running Python tests with coverage..."
 
@@ -34,4 +32,8 @@ fi
 
 log_info "Coverage: ${PERCENT}%"
 log_info "Report: ${COVERAGE_DIR}/index.html"
-bash "$(dirname "$0")/../common/check-coverage.sh" "$PERCENT"
+_tag=""
+if command -v jq >/dev/null 2>&1; then
+  _tag=$(echo "${COVERAGE_CONFIG_PYTHON:-}" | jq -r '.tag // empty' 2>/dev/null)
+fi
+bash "$(dirname "$0")/../common/check-coverage.sh" "$PERCENT" "${_tag:-${COVERAGE_TAG:-}}" "${COVERAGE_CONFIG_PYTHON:-}"

--- a/scripts/shell/coverage.sh
+++ b/scripts/shell/coverage.sh
@@ -154,8 +154,12 @@ if [ -n "$COVERAGE_FILE" ]; then
   PERCENT=$(jq -r '.percent_covered' "$COVERAGE_FILE")
   log_info "Report: ${REPORT_DIR}/index.html" >&2
 
-  # Check against baseline
-  bash "$REPO_ROOT/scripts/common/check-coverage.sh" "$PERCENT" "${COVERAGE_TAG:-}"
+  # Check against baseline — prefer tag from COVERAGE_CONFIG_SHELL, fall back to COVERAGE_TAG
+  _tag=""
+  if command -v jq >/dev/null 2>&1; then
+    _tag=$(echo "${COVERAGE_CONFIG_SHELL:-}" | jq -r '.tag // empty' 2>/dev/null)
+  fi
+  bash "$REPO_ROOT/scripts/common/check-coverage.sh" "$PERCENT" "${_tag:-${COVERAGE_TAG:-}}" "${COVERAGE_CONFIG_SHELL:-}"
 else
   log_error "Could not determine coverage." >&2
   exit 1

--- a/tests/scripts/common/check-coverage.bats
+++ b/tests/scripts/common/check-coverage.bats
@@ -162,6 +162,40 @@ teardown() {
   [[ "$output" == *"Skipping delta check"* ]]
 }
 
+# ── Runner config (number mode — shell/go/python) ────────────────
+
+@test "runner config: uses floor from runner config over legacy COVERAGE_FLOOR" {
+  printf 'COVERAGE_FLOOR=95\n' >.hooks-config
+  git add .hooks-config
+  run bash "$SCRIPT" 82 "" '{"floor":80,"delta":0.05}'
+  [ "$status" -eq 0 ]
+}
+
+@test "runner config: uses delta from runner config over legacy COVERAGE_MAX_DROP" {
+  echo "90" >.coverage-baseline
+  printf 'COVERAGE_FLOOR=80\nCOVERAGE_MAX_DROP=0.05\n' >.hooks-config
+  git add .hooks-config
+  run bash "$SCRIPT" 82 "" '{"floor":80,"delta":10}'
+  [ "$status" -eq 0 ]
+}
+
+@test "runner config: falls back to legacy floor when runner config is empty" {
+  printf 'COVERAGE_FLOOR=95\n' >.hooks-config
+  git add .hooks-config
+  run bash "$SCRIPT" 82 "" ""
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"below floor threshold"* ]]
+}
+
+@test "runner config: uses tag from second arg to look up tagged baseline" {
+  printf 'shell: 80\njs: 90\n' >.coverage-baseline
+  printf 'COVERAGE_FLOOR=70\n' >.hooks-config
+  git add .hooks-config
+  run bash "$SCRIPT" 82 "shell" '{"floor":70,"delta":5}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"baseline: 80%"* ]]
+}
+
 # ── JSON mode (node — per-metric) ────────────────────────────────
 
 JSON_METRICS='{"lines":85,"statements":82,"functions":78,"branches":72}'


### PR DESCRIPTION
## Summary

  - `COVERAGE_TAG` in `.hooks-config` was shared across all runners, causing
    shell/go/python runners to inherit the node tag (e.g. `js`) and look up
    the wrong baseline entry
  - Adds `tag` field to all `COVERAGE_CONFIG_*` JSON objects — each runner
    now reads its own tag, falling back to `COVERAGE_TAG` for backward compat
  - `check-coverage.sh` number mode now accepts a 3rd arg (runner config JSON)
    and reads `floor`/`delta` from it, overriding legacy `COVERAGE_FLOOR`/
    `COVERAGE_MAX_DROP` — shell/go/python runner-specific configs are now
    actually consumed (previously defined but silently ignored)
  - Go and Python runners now source `config.sh` instead of just `utils.sh`
    to access their runner-specific config

Closes #89