### PR TITLE
docs(deploy/netlify): clarify production input description (#91)

### DIFF
--- a/actions/deploy/netlify/action.yml
+++ b/actions/deploy/netlify/action.yml
@@ -23,7 +23,10 @@ inputs:
     default: './dist'
 
   production:
-    description: Whether this is a production deploy
+    description: >
+      Whether to deploy to this site's production channel (custom domain).
+      Defaults to true. Set to false only if you want a draft/preview URL instead.
+      Note: QA and production environment isolation is handled via site-id, not this flag.
     required: false
     default: 'true'
 


### PR DESCRIPTION
## Summary
  - Expands the `production` input description in `actions/deploy/netlify/action.yml`
  - Clarifies that the flag controls Netlify's production channel (custom domain), not environment isolation
  - Explicitly documents that QA vs production isolation is achieved via `site-id`, not this flag — preventing misconfiguration by consumers                                            

Closes #91