### PR TITLE
fix(tpl-release): remove consumer npm ci — unblocks non-Node repos (#94)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -50,7 +50,7 @@
       }
     ],
     [
-      "./src/plugins/verified-commit.js",
+      "./.git/modules/core-actions/src/plugins/verified-commit.js",
       {
         "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/actions/release/semantic-release/action.yml
+++ b/actions/release/semantic-release/action.yml
@@ -16,7 +16,7 @@ inputs:
 
   working-directory:
     description: >
-      Directory containing package.json. Defaults to repo root.
+      Working directory for semantic-release. Defaults to repo root.
     required: false
     default: '.'
 
@@ -52,11 +52,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-
-    - name: Install dependencies
-      shell: bash
-      run: npm ci
-      working-directory: ${{ inputs.working-directory }}
 
     - name: Read git identity
       id: git-identity


### PR DESCRIPTION
## Problem                                                                                            
  `tpl-release.yml` ran `npm ci` in the consumer's working directory                                    
  before semantic-release. This required every consumer repo to have a                                  
  `package.json` and `package-lock.json` even when the project is Go,                                   
  Python, or shell.                                                                                     
                                                                                                        
  ## Solution                                                                                         
  - Removed `npm ci` from `actions/release/semantic-release/action.yml`                                 
  - All plugin deps (`@octokit/rest` etc.) belong to core-actions and are
    already installed via `npm ci` in `.git/modules/core-actions` inside                                
    `tpl-release.yml` — consumers never needed to own them                                              
  - Updated `.releaserc.json` plugin path to reference `verified-commit.js`                             
    via the module checkout (`.git/modules/core-actions/src/plugins/...`),                              
    consistent with all consumer repos and ensuring Node resolves deps from                           
    core-actions' own `node_modules`                                                                    
                                                                     
  ## Impact                                                                                             
  - Node repos (folios-web, folios-portfolio): no change in behaviour                                   
  - Non-Node repos (Go, Python, shell): can now use `tpl-release.yml`                                   
    without a `package.json`                                                                            
                                                                                                        
  Closes #94 