### PR TITLE
fix(tpl-common-ci): install tools from core-actions not consumer (#95)

### DIFF
--- a/.github/workflows/tpl-common-ci.yml
+++ b/.github/workflows/tpl-common-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node-version:
-        description: Node.js version (for cspell, prettier, markdownlint)
+        description: Node.js version for core-actions tooling
         type: string
         required: false
         default: '22'
@@ -66,6 +66,10 @@ jobs:
           path: .git/modules/core-actions
           token: ${{ steps.cross-repo-token.outputs.token || github.token }}
 
+      - uses: ./.git/modules/core-actions/actions/ci/setup-tools
+        with:
+          node-version: ${{ inputs.node-version }}
+
       - uses: ./.git/modules/core-actions/actions/ci/quality-gate
         with:
           scripts-dir: .git/modules/core-actions/scripts/common
@@ -98,12 +102,9 @@ jobs:
           path: .git/modules/core-actions
           token: ${{ steps.cross-repo-token.outputs.token || github.token }}
 
-      - uses: actions/setup-node@v4
+      - uses: ./.git/modules/core-actions/actions/ci/setup-tools
         with:
           node-version: ${{ inputs.node-version }}
-
-      - name: Install tools
-        run: npm ci
 
       - uses: ./.git/modules/core-actions/actions/ci/quality-lint
         with:
@@ -136,6 +137,10 @@ jobs:
           ref: ${{ inputs.core-actions-ref }}
           path: .git/modules/core-actions
           token: ${{ steps.cross-repo-token.outputs.token || github.token }}
+
+      - uses: ./.git/modules/core-actions/actions/ci/setup-tools
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - uses: ./.git/modules/core-actions/actions/ci/quality-links
         with:

--- a/actions/ci/setup-tools/action.yml
+++ b/actions/ci/setup-tools/action.yml
@@ -1,0 +1,31 @@
+name: Setup CI Tools
+description: >
+  Installs core-actions dependencies and adds their binaries to PATH.
+  Called by CI jobs before running quality checks so tools like prettier,
+  cspell, and markdownlint-cli2 are available regardless of the consumer's
+  tech stack.
+
+inputs:
+  node-version:
+    description: Node.js version to use
+    required: false
+    default: '22'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install core-actions dependencies
+      shell: bash
+      run: npm ci
+      working-directory: ${{ github.action_path }}/../../..
+
+    - name: Add core-actions tools to PATH
+      shell: bash
+      run: |
+        CORE_ACTIONS_ROOT="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        echo "$CORE_ACTIONS_ROOT/node_modules/.bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Problem                                                                                            
  The `lint` job in `tpl-common-ci.yml` ran `npm ci` in the consumer's                                  
  working directory to install prettier, cspell, and markdownlint-cli2.                                 
  This required consumer repos to have a `package.json` with these tools                                
  as devDependencies even though they belong to core-actions.                                         
                                                                                                        
  ## Solution                                                           
  - Added `actions/ci/setup-tools` composite action that installs                                       
    core-actions' own dependencies and adds `node_modules/.bin` to                                    
    `$GITHUB_PATH` — tools are always resolved from core-actions                                        
  - Applied `setup-tools` consistently to all three quality jobs                                        
    (gate, lint, links), not just lint — any npm tool added to any                                      
    quality action in the future works automatically                                                    
  - `github.action_path` makes the action self-locating — resolves                                      
    correctly whether called from core-actions itself or a consumer repo                                
                                                                                                      
  ## Impact                                                                                             
  - Consumer repos need zero changes — no `package.json` required                                       
    for quality checks                                                                                  
  - Go, Python, shell repos can now use `tpl-common-ci.yml` without                                     
    any npm setup                                                                                       
  - Tool versions remain pinned in core-actions' `package.json`                                         
                                                                                                        
  Closes #95