### PR TITLE
fix(tpl-shell-ci): source tools from core-actions, align with templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/tpl-shell-ci.yml
     with:
       coverage-tag: shell
+      core-actions-ref: ${{ github.head_ref || github.ref_name }}
 
   js-test:
     name: JS Tests

--- a/.github/workflows/tpl-shell-ci.yml
+++ b/.github/workflows/tpl-shell-ci.yml
@@ -3,16 +3,32 @@ name: Shell CI
 on:
   workflow_call:
     inputs:
-      node-version:
-        description: Node.js version (for bats via npm)
-        type: string
-        required: false
-        default: '22'
       coverage-tag:
         description: Coverage baseline tag (leave empty for legacy single-baseline mode)
         type: string
         required: false
         default: ''
+
+      core-actions-ref:
+        description: Git ref for core-actions checkout (tag, branch, or SHA)
+        type: string
+        required: false
+        default: 'main'
+
+      owner:
+        description: GitHub owner for app token scope (defaults to repository owner)
+        type: string
+        required: false
+        default: ''
+
+    secrets:
+      APP_ID:
+        description: GitHub App ID — required when calling from a repo that cannot access core-actions with the default token
+        required: false
+
+      APP_PRIVATE_KEY:
+        description: GitHub App private key (pairs with APP_ID)
+        required: false
 
 permissions:
   contents: read
@@ -22,17 +38,30 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      HAS_APP_CREDS: ${{ secrets.APP_ID != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Generate cross-repo token
+        if: env.HAS_APP_CREDS == 'true'
+        id: cross-repo-token
+        uses: actions/create-github-app-token@v1
         with:
-          node-version: ${{ inputs.node-version }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ inputs.owner || github.repository_owner }}
 
-      - name: Install dependencies
-        run: npm ci
+      - uses: actions/checkout@v4
+        with:
+          repository: leaflockio/core-actions
+          ref: ${{ inputs.core-actions-ref }}
+          path: .git/modules/core-actions
+          token: ${{ steps.cross-repo-token.outputs.token || github.token }}
+
+      - uses: ./.git/modules/core-actions/actions/ci/setup-tools
 
       - name: Lint shell scripts
         env:
@@ -43,21 +72,34 @@ jobs:
             echo "No shell files changed in this PR."
             exit 0
           fi
-          echo "$FILES" | xargs npx shellcheck -x --source-path=SCRIPTDIR
+          echo "$FILES" | xargs shellcheck -x --source-path=SCRIPTDIR
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      HAS_APP_CREDS: ${{ secrets.APP_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Generate cross-repo token
+        if: env.HAS_APP_CREDS == 'true'
+        id: cross-repo-token
+        uses: actions/create-github-app-token@v1
         with:
-          node-version: ${{ inputs.node-version }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ inputs.owner || github.repository_owner }}
 
-      - name: Install dependencies
-        run: npm ci
+      - uses: actions/checkout@v4
+        with:
+          repository: leaflockio/core-actions
+          ref: ${{ inputs.core-actions-ref }}
+          path: .git/modules/core-actions
+          token: ${{ steps.cross-repo-token.outputs.token || github.token }}
+
+      - uses: ./.git/modules/core-actions/actions/ci/setup-tools
 
       - name: Run tests with coverage
         env:


### PR DESCRIPTION
## Problem
  Both jobs in `tpl-shell-ci.yml` ran `npm ci` in the consumer's working
  directory to install bats and shellcheck. This required consumer repos
  to maintain a `package.json` with these tools as devDependencies even
  though they belong to core-actions.

  Additionally, the template was missing core-actions checkout entirely,
  making it the only template inconsistent with the rest.

  ## Solution
  - Added core-actions checkout + `setup-tools` action to both jobs —
    bats and shellcheck are now sourced from core-actions' own
    `node_modules/.bin` via `$GITHUB_PATH`
  - Removed `node-version` input (owned by `setup-tools`), `setup-node`,
    and consumer-side `npm ci` from both jobs
  - Added `core-actions-ref`, `owner` inputs and optional
    `APP_ID`/`APP_PRIVATE_KEY` secrets — consistent with all other templates
  - `npx shellcheck` → `shellcheck` (binary now in PATH via `setup-tools`)
  - Updated `ci.yml` to pass `core-actions-ref` to the shell job so it
    tests against the current branch, consistent with the quality job

  ## Impact
  - Consumer repos need zero npm setup for shell CI
  - No breaking changes — `coverage-tag` input unchanged, coverage script
    invocation unchanged

  Closes #96