### PR TITLE
fix(release): make extra-plugins additive over base plugin set

### DIFF
--- a/.github/workflows/tpl-release.yml
+++ b/.github/workflows/tpl-release.yml
@@ -26,7 +26,7 @@ on:
           Space-separated list of extra semantic-release plugins to install
         type: string
         required: false
-        default: '@semantic-release/changelog @semantic-release/git @octokit/rest conventional-changelog-conventionalcommits'
+        default: ''
 
       update-major-tag:
         description: Whether to move the major version tag after release (e.g. v1 → v1.2.0)

--- a/actions/release/semantic-release/action.yml
+++ b/actions/release/semantic-release/action.yml
@@ -65,7 +65,9 @@ runs:
       uses: cycjimmy/semantic-release-action@v4.2.0
       with:
         semantic_version: ${{ inputs.semantic-version }}
-        extra_plugins: ${{ inputs.extra-plugins }}
+        extra_plugins: >-
+          @semantic-release/changelog @semantic-release/git @octokit/rest conventional-changelog-conventionalcommits
+          ${{ inputs.extra-plugins }}
         working_directory: ${{ inputs.working-directory }}
       env:
         GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
## Summary 
                                                                                                        
  Closes #103                            
                                                                                                        
  - Hardcoded the 4 base plugins (`@semantic-release/changelog`, `@semantic-release/git`,
  `@octokit/rest`, `conventional-changelog-conventionalcommits`) directly in             
  `actions/release/semantic-release/action.yml` so they are always installed
  - `extra-plugins` is now truly additive — consumers only pass what they need beyond the standard set
  - Removed the base plugins from `tpl-release.yml`'s `extra-plugins` default (now `''`)                
                                                                                        
  ## Consumer impact                                                                                    
                                                                                                        
  `core-cli` currently repeats the full base set to add `@semantic-release/exec`. After updating to this
   release, it can simplify to:                                                                         
                                                                  
  ```yaml                                                                                               
  extra-plugins: '@semantic-release/exec' 
```