### PR TITLE
fix(go): skip lint when no Go files changed, scope to changed files only

### DIFF
--- a/.github/workflows/tpl-go-ci.yml
+++ b/.github/workflows/tpl-go-ci.yml
@@ -95,10 +95,20 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
           working-directory: ${{ inputs.working-directory }}
 
+      - name: Check for changed Go files
+        id: go-files
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          FILES=$(git diff --name-only --diff-filter=ACMR "$PR_BASE_SHA"...HEAD -- '*.go')
+          echo "changed=$( [ -n "$FILES" ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
+
       - uses: golangci/golangci-lint-action@v6
+        if: steps.go-files.outputs.changed == 'true'
         with:
           version: ${{ inputs.golangci-lint-version }}
           working-directory: ${{ inputs.working-directory }}
+          only-new-issues: true
 
   coverage:
     name: Coverage

--- a/scripts/go/check-lint.sh
+++ b/scripts/go/check-lint.sh
@@ -5,13 +5,22 @@
 # software, via any medium, is strictly prohibited without prior
 # written permission from Leaflock.
 
-# Runs golangci-lint on the entire module.
+# Runs golangci-lint on changed Go files only.
 
-. "$(dirname "$0")/../common/utils.sh"
+. "$(dirname "$0")/../common/config.sh"
+
+FILES=$(echo "$CHECK_FILES" | grep '\.go$')
+
+if [ -z "$FILES" ]; then
+  log_info "No Go files to lint."
+  exit 0
+fi
+
+mapfile -t PACKAGES < <(echo "$FILES" | xargs dirname | sort -u | sed 's|^[^./]|./&|')
 
 log_info "Running golangci-lint..."
 
-if ! golangci-lint run ./...; then
+if ! golangci-lint run "${PACKAGES[@]}"; then
   log_error "Go lint check failed. Fix the issues above."
   exit 1
 fi

--- a/tests/scripts/go/check-lint.bats
+++ b/tests/scripts/go/check-lint.bats
@@ -3,6 +3,11 @@
 setup() {
   load "../../test_helper/common-setup"
   _common_setup
+  init_test_repo
+
+  echo "init" >README.md
+  git add README.md
+  git commit -m "init"
 
   SCRIPT="${PROJECT_ROOT}/scripts/go/check-lint.sh"
 }
@@ -11,8 +16,22 @@ teardown() {
   _common_teardown
 }
 
+@test "passes silently when no Go files are staged" {
+  echo "" >config.yml
+  git add config.yml
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No Go files to lint"* ]]
+}
+
 @test "passes when golangci-lint succeeds" {
   create_mock "golangci-lint" 'exit 0'
+
+  cat >main.go <<'EOF'
+package main
+EOF
+  git add main.go
 
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
@@ -22,15 +41,111 @@ teardown() {
 @test "fails when golangci-lint fails" {
   create_mock "golangci-lint" 'exit 1'
 
+  cat >main.go <<'EOF'
+package main
+EOF
+  git add main.go
+
   run bash "$SCRIPT"
   [ "$status" -eq 1 ]
   [[ "$output" == *"Go lint check failed"* ]]
 }
 
-@test "shows running message" {
-  create_mock "golangci-lint" 'exit 0'
+@test "lints root package for root-level Go file" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  cat >main.go <<'EOF'
+package main
+EOF
+  git add main.go
 
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Running golangci-lint"* ]]
+  [[ "$output" == *"called: run ."* ]]
+}
+
+@test "lints correct package for subdirectory Go file" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  mkdir -p cmd
+  cat >cmd/main.go <<'EOF'
+package main
+EOF
+  git add cmd/main.go
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"./cmd"* ]]
+}
+
+@test "deduplicates packages when multiple files in same directory are staged" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  mkdir -p internal/foo
+  cat >internal/foo/a.go <<'EOF'
+package foo
+EOF
+  cat >internal/foo/b.go <<'EOF'
+package foo
+EOF
+  git add internal/foo/a.go internal/foo/b.go
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # ./internal/foo should appear exactly once
+  count=$(echo "$output" | grep -o '\./internal/foo' | wc -l)
+  [ "$count" -eq 1 ]
+}
+
+@test "lints multiple packages when files from different directories are staged" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  mkdir -p cmd internal/foo
+  cat >cmd/main.go <<'EOF'
+package main
+EOF
+  cat >internal/foo/bar.go <<'EOF'
+package foo
+EOF
+  git add cmd/main.go internal/foo/bar.go
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"./cmd"* ]]
+  [[ "$output" == *"./internal/foo"* ]]
+}
+
+@test "does not lint unstaged Go files" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  cat >staged.go <<'EOF'
+package main
+EOF
+  cat >unstaged.go <<'EOF'
+package main
+EOF
+  git add staged.go
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"unstaged"* ]]
+}
+
+@test "lints all packages in CHECK_MODE=all" {
+  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+
+  mkdir -p cmd
+  cat >main.go <<'EOF'
+package main
+EOF
+  cat >cmd/run.go <<'EOF'
+package cmd
+EOF
+  git add main.go cmd/run.go
+  git commit -m "add go files"
+
+  CHECK_MODE=all run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"."* ]]
+  [[ "$output" == *"./cmd"* ]]
 }


### PR DESCRIPTION
## Summary

  Closes #105

  - **Hook (`check-lint.sh`)**: Sources `config.sh` to respect `CHECK_MODE`
    (staged/pr/all), exits silently when no Go files are in scope, and
    derives package paths from changed files so only affected packages
    are linted
  - **CI (`tpl-go-ci.yml`)**: Adds a guard step using the same
    `git diff --diff-filter=ACMR ... -- '*.go'` logic as `config.sh` PR
    mode — skips the lint job entirely when no Go files changed; enables
    `only-new-issues: true` to scope golangci-lint to PR changes only
