### PR TITLE
fix(go): skip coverage when no Go packages exist

### DIFF
--- a/scripts/go/coverage.sh
+++ b/scripts/go/coverage.sh
@@ -9,6 +9,11 @@
 
 . "$(dirname "$0")/../common/config.sh"
 
+if [ -z "$(go list ./... 2>/dev/null)" ]; then
+  log_info "No Go packages found, skipping coverage."
+  exit 0
+fi
+
 log_info "Running Go tests with coverage..."
 
 mkdir -p "$COVERAGE_DIR"

--- a/tests/scripts/go/coverage.bats
+++ b/tests/scripts/go/coverage.bats
@@ -16,9 +16,24 @@ teardown() {
   _common_teardown
 }
 
+@test "skips when no Go packages found" {
+  create_mock "go" '
+    if [ "$1" = "list" ]; then
+      exit 0
+    fi
+  '
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No Go packages found, skipping coverage"* ]]
+}
+
 @test "passes when tests pass and coverage meets baseline" {
   create_mock "go" '
-    if [ "$1" = "test" ]; then
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
       echo "ok"
       touch coverage.out
       exit 0
@@ -39,7 +54,10 @@ teardown() {
 
 @test "fails when tests fail" {
   create_mock "go" '
-    if [ "$1" = "test" ]; then
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
       echo "FAIL"
       exit 1
     fi
@@ -52,7 +70,10 @@ teardown() {
 
 @test "fails when coverage cannot be extracted" {
   create_mock "go" '
-    if [ "$1" = "test" ]; then
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
       exit 0
     elif [ "$1" = "tool" ]; then
       echo ""
@@ -67,7 +88,10 @@ teardown() {
 
 @test "shows running message" {
   create_mock "go" '
-    if [ "$1" = "test" ]; then
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
       touch coverage.out
       exit 0
     elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-func"; then


### PR DESCRIPTION
## Summary                                                                                                
                                                                                                          
  - `coverage` job failed when a Go project had no `.go` files (e.g. initial repo setup), because `go test  
  ./...` errors out with nothing to test                                                                    
  - Added a `go list ./...` guard in `scripts/go/coverage.sh` to exit 0 cleanly when no packages exist —    
  lets the job pass without complaint                                                                       
  - Updated `tests/scripts/go/coverage.bats` to cover the new skip path and fixed existing mocks to handle
  `go list` so they don't false-exit early                                                                  
                                                                                                
  closes #107                                                                                               
                