### PR TITLE
fix(go): add -race flag to coverage test command

### DIFF
--- a/scripts/go/coverage.sh
+++ b/scripts/go/coverage.sh
@@ -18,7 +18,7 @@ log_info "Running Go tests with coverage..."
 
 mkdir -p "$COVERAGE_DIR"
 
-OUTPUT=$(go test -coverprofile="$COVERAGE_DIR/coverage.out" ./... 2>&1)
+OUTPUT=$(go test -race -coverprofile="$COVERAGE_DIR/coverage.out" ./... 2>&1)
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/tests/scripts/go/coverage.bats
+++ b/tests/scripts/go/coverage.bats
@@ -52,6 +52,32 @@ teardown() {
   [[ "$output" == *"Coverage: 96"* ]]
 }
 
+@test "runs tests with race detector" {
+  create_mock "go" '
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
+      if ! echo "$*" | grep -q "\-race"; then
+        echo "missing -race flag"
+        exit 1
+      fi
+      touch coverage.out
+      exit 0
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-func"; then
+      echo "total:	(statements)	96.0%"
+      exit 0
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-html"; then
+      exit 0
+    fi
+  '
+
+  echo "96.0" >.coverage-baseline
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
 @test "fails when tests fail" {
   create_mock "go" '
     if [ "$1" = "list" ]; then


### PR DESCRIPTION
## Summary                                                                                                
                                                                                                          
  - `go test` in `scripts/go/coverage.sh` was missing the `-race` flag, meaning race conditions would go
  undetected in CI                                                                                          
  - Added `-race` to the `go test` command
  - Added a test that explicitly verifies `-race` is passed                                                 
                                           
  Closes #108