### PR TITLE
feat(go): add command field to COVERAGE_CONFIG_GO

### DIFF
--- a/scripts/go/coverage.sh
+++ b/scripts/go/coverage.sh
@@ -18,7 +18,10 @@ log_info "Running Go tests with coverage..."
 
 mkdir -p "$COVERAGE_DIR"
 
-OUTPUT=$(go test -race -coverprofile="$COVERAGE_DIR/coverage.out" ./... 2>&1)
+_cmd=$(echo "${COVERAGE_CONFIG_GO:-}" | jq -r '.command // empty' 2>/dev/null)
+COVERAGE_CMD="${_cmd:-go test -race -coverprofile="$COVERAGE_DIR/coverage.out" ./...}"
+
+OUTPUT=$(eval "$COVERAGE_CMD" 2>&1)
 STATUS=$?
 
 if [ "$STATUS" -ne 0 ]; then

--- a/tests/scripts/go/coverage.bats
+++ b/tests/scripts/go/coverage.bats
@@ -131,3 +131,52 @@ teardown() {
   run bash "$SCRIPT"
   [[ "$output" == *"Running Go tests with coverage"* ]]
 }
+
+@test "uses custom command from COVERAGE_CONFIG_GO" {
+  create_mock "go" '
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
+      echo "go test should not be called with custom command"
+      exit 1
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-func"; then
+      echo "total:	(statements)	96.0%"
+      exit 0
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-html"; then
+      exit 0
+    fi
+  '
+
+  export COVERAGE_CONFIG_GO='{"command": "touch coverage/coverage.out"}'
+  echo "96.0" >.coverage-baseline
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Coverage: 96"* ]]
+}
+
+@test "falls back to default command when no command field in COVERAGE_CONFIG_GO" {
+  create_mock "go" '
+    if [ "$1" = "list" ]; then
+      echo "example.com/pkg"
+      exit 0
+    elif [ "$1" = "test" ]; then
+      mkdir -p coverage
+      touch coverage/coverage.out
+      exit 0
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-func"; then
+      echo "total:	(statements)	96.0%"
+      exit 0
+    elif [ "$1" = "tool" ] && [ "$2" = "cover" ] && echo "$*" | grep -q "\-html"; then
+      exit 0
+    fi
+  '
+
+  export COVERAGE_CONFIG_GO='{"tag": "v1"}'
+  echo "96.0" >.coverage-baseline
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Coverage: 96"* ]]
+}


### PR DESCRIPTION
## Summary                                                                                           
                                                                                                       
  Closes #112                                                                                          
                                                                                                       
  - Adds a `command` field to `COVERAGE_CONFIG_GO` that lets consumers override the default `go test`  
  invocation                                                                                           
  - Falls back to `go test -race -coverprofile="$COVERAGE_DIR/coverage.out" ./...` when no `command` is
   set — no behaviour change for existing consumers                                                    
  - Coverage percentage extraction via `go tool cover -func` remains fixed in the script regardless of
  custom command                                                                                       
                                                                                                     
  ## Consumer usage                                                                                    
                                                                                                     
  In `.hooks-config`:                                                                                  
  COVERAGE_CONFIG_GO={"tag": "v1", "command": "go test -race -coverprofile="$COVERAGE_DIR/coverage.out"
   ./internal/..."}                                                                                    
                                                                                                     
  CI reads `.hooks-config` via `config.sh` — no workflow changes needed. 