### PR TITLE
fix(shell): pass --no-must-find-files to cspell (#115)

### DIFF
--- a/scripts/common/check-spelling.sh
+++ b/scripts/common/check-spelling.sh
@@ -19,7 +19,7 @@ fi
 
 log_info "Checking spelling..."
 
-if ! echo "$CHECK_FILES" | xargs npx cspell --no-progress --no-summary 2>&1; then
+if ! echo "$CHECK_FILES" | xargs npx cspell --no-progress --no-summary --no-must-find-files 2>&1; then
   echo ""
   log_error "Spelling errors detected."
   log_info "Fix the words above or add them to .cspell.json 'words' list."


### PR DESCRIPTION

  Fixes #115                                                                                           
                                                                                                     
  cspell exits non-zero when none of the passed files match its configured                             
  patterns. Adding `--no-must-find-files` makes it exit 0 in that case    
  instead of failing the spelling check. 