### PR TITLE
fix(go-ci): fetch base SHA before diff to fix shallow clone error

### DIFF
--- a/.github/workflows/tpl-go-ci.yml
+++ b/.github/workflows/tpl-go-ci.yml
@@ -95,6 +95,11 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
           working-directory: ${{ inputs.working-directory }}
 
+      - name: Fetch base SHA
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --depth=1 origin "$PR_BASE_SHA"
+
       - name: Check for changed Go files
         id: go-files
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.5.1-beta.1](https://github.com/leaflockio/core-actions/compare/v1.5.0...v1.5.1-beta.1) (2026-04-26)
+
+### Bug Fixes
+
+* **shell:** pass --no-must-find-files to cspell ([#115](https://github.com/leaflockio/core-actions/issues/115)) ([#118](https://github.com/leaflockio/core-actions/issues/118)) ([ca1243d](https://github.com/leaflockio/core-actions/commit/ca1243d700313e51b68052fd853502c4fbb58380))
+
 ## [1.5.0](https://github.com/leaflockio/core-actions/compare/v1.4.2...v1.5.0) (2026-04-18)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@leaflockio/core-actions",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@leaflockio/core-actions",
-      "version": "1.5.0",
+      "version": "1.5.1-beta.1",
       "devDependencies": {
         "@eslint/compat": "^2.0.4",
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leaflockio/core-actions",
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "private": true,
   "type": "module",
   "description": "Reusable GitHub Actions, composite actions, and shared scripts for Leaflock repositories",

--- a/scripts/common/check-spelling.sh
+++ b/scripts/common/check-spelling.sh
@@ -19,7 +19,7 @@ fi
 
 log_info "Checking spelling..."
 
-if ! echo "$CHECK_FILES" | xargs npx cspell --no-progress --no-summary 2>&1; then
+if ! echo "$CHECK_FILES" | xargs npx cspell --no-progress --no-summary --no-must-find-files 2>&1; then
   echo ""
   log_error "Spelling errors detected."
   log_info "Fix the words above or add them to .cspell.json 'words' list."


### PR DESCRIPTION
## Summary
                                                                                                       
  Fixes #116                                                                                         

  `actions/checkout@v4` produces a shallow clone by default. The base                                  
  commit referenced by `PR_BASE_SHA` is not present in local history,
  causing `git diff "$PR_BASE_SHA"...HEAD` to fail with:                                               
                                                                                                     
  fatal: Invalid symmetric difference expression ...HEAD                                               
                                                                                                     
  ## Change                                                                                            
                                                                                                     
  Added a "Fetch base SHA" step in the `lint` job before the changed-files                             
  check, fetching only the base commit with `--depth=1` so the three-dot
  diff resolves correctly.                                                                             
            