### PR TITLE
fix(go-ci): fetch base SHA before diff to fix shallow clone error (#116)

### DIFF
--- a/.github/workflows/tpl-go-ci.yml
+++ b/.github/workflows/tpl-go-ci.yml
@@ -95,6 +95,11 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
           working-directory: ${{ inputs.working-directory }}
 
+      - name: Fetch base SHA
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --depth=1 origin "$PR_BASE_SHA"
+
       - name: Check for changed Go files
         id: go-files
         env:


### PR DESCRIPTION
## Summary
                                                                                                       
  Fixes #116                                                                                         

  `actions/checkout@v4` produces a shallow clone by default. The base                                  
  commit referenced by `PR_BASE_SHA` is not present in local history,
  causing `git diff "$PR_BASE_SHA"...HEAD` to fail with:                                               
                                                                                                     
  fatal: Invalid symmetric difference expression ...HEAD                                               

## Change                                                                                            
                                                                                                     
  Added a "Fetch base SHA" step in the `lint` job before the changed-files                             
  check, fetching only the base commit with `--depth=1` so the three-dot
  diff resolves correctly.                                                                             
