### PR TITLE
fix(go): scope hook lint to staged changes via --new-from-patch (#117)

### DIFF
--- a/scripts/go/check-lint.sh
+++ b/scripts/go/check-lint.sh
@@ -16,13 +16,16 @@ if [ -z "$FILES" ]; then
   exit 0
 fi
 
-mapfile -t PACKAGES < <(echo "$FILES" | xargs dirname | sort -u | sed 's|^[^./]|./&|')
-
 log_info "Running golangci-lint..."
 
-if ! golangci-lint run "${PACKAGES[@]}"; then
+PATCH=$(mktemp)
+git diff --cached -- '*.go' >"$PATCH"
+
+if ! golangci-lint run --new-from-patch "$PATCH" ./...; then
+  rm -f "$PATCH"
   log_error "Go lint check failed. Fix the issues above."
   exit 1
 fi
 
+rm -f "$PATCH"
 log_success "Go lint check passed."

--- a/tests/scripts/go/check-lint.bats
+++ b/tests/scripts/go/check-lint.bats
@@ -51,8 +51,8 @@ EOF
   [[ "$output" == *"Go lint check failed"* ]]
 }
 
-@test "lints root package for root-level Go file" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+@test "passes --new-from-patch flag to golangci-lint" {
+  create_mock "golangci-lint" 'echo "args: $*"; exit 0'
 
   cat >main.go <<'EOF'
 package main
@@ -61,62 +61,24 @@ EOF
 
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"called: run ."* ]]
+  [[ "$output" == *"--new-from-patch"* ]]
 }
 
-@test "lints correct package for subdirectory Go file" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+@test "passes ./... as lint target to golangci-lint" {
+  create_mock "golangci-lint" 'echo "args: $*"; exit 0'
 
-  mkdir -p cmd
-  cat >cmd/main.go <<'EOF'
+  cat >main.go <<'EOF'
 package main
 EOF
-  git add cmd/main.go
+  git add main.go
 
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"./cmd"* ]]
+  [[ "$output" == *"./..."* ]]
 }
 
-@test "deduplicates packages when multiple files in same directory are staged" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
-
-  mkdir -p internal/foo
-  cat >internal/foo/a.go <<'EOF'
-package foo
-EOF
-  cat >internal/foo/b.go <<'EOF'
-package foo
-EOF
-  git add internal/foo/a.go internal/foo/b.go
-
-  run bash "$SCRIPT"
-  [ "$status" -eq 0 ]
-  # ./internal/foo should appear exactly once
-  count=$(echo "$output" | grep -o '\./internal/foo' | wc -l)
-  [ "$count" -eq 1 ]
-}
-
-@test "lints multiple packages when files from different directories are staged" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
-
-  mkdir -p cmd internal/foo
-  cat >cmd/main.go <<'EOF'
-package main
-EOF
-  cat >internal/foo/bar.go <<'EOF'
-package foo
-EOF
-  git add cmd/main.go internal/foo/bar.go
-
-  run bash "$SCRIPT"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"./cmd"* ]]
-  [[ "$output" == *"./internal/foo"* ]]
-}
-
-@test "does not lint unstaged Go files" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+@test "patch contains only staged Go files" {
+  create_mock "golangci-lint" 'cat "$3"; exit 0'
 
   cat >staged.go <<'EOF'
 package main
@@ -128,24 +90,34 @@ EOF
 
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" != *"unstaged"* ]]
+  [[ "$output" == *"staged.go"* ]]
+  [[ "$output" != *"unstaged.go"* ]]
 }
 
-@test "lints all packages in CHECK_MODE=all" {
-  create_mock "golangci-lint" 'echo "called: $*"; exit 0'
+@test "cleans up patch file after success" {
+  create_mock "golangci-lint" 'echo "PATCH_PATH=$3"; exit 0'
 
-  mkdir -p cmd
   cat >main.go <<'EOF'
 package main
 EOF
-  cat >cmd/run.go <<'EOF'
-package cmd
-EOF
-  git add main.go cmd/run.go
-  git commit -m "add go files"
+  git add main.go
 
-  CHECK_MODE=all run bash "$SCRIPT"
+  run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"."* ]]
-  [[ "$output" == *"./cmd"* ]]
+  patch_path=$(echo "$output" | grep "PATCH_PATH=" | sed 's/PATCH_PATH=//')
+  [ ! -f "$patch_path" ]
+}
+
+@test "cleans up patch file after failure" {
+  create_mock "golangci-lint" 'echo "PATCH_PATH=$3"; exit 1'
+
+  cat >main.go <<'EOF'
+package main
+EOF
+  git add main.go
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  patch_path=$(echo "$output" | grep "PATCH_PATH=" | sed 's/PATCH_PATH=//')
+  [ ! -f "$patch_path" ]
 }


### PR DESCRIPTION
  ## Summary                                                                                           
                                                                                                     
  Fixes #117                                                                                           
  
  The hook was running `golangci-lint run "${PACKAGES[@]}"` which linted                               
  entire packages. Two problems with this:                                                           
                                                                                                       
  - `mapfile` is unavailable on macOS bash 3.2, leaving `PACKAGES` empty                               
    and causing golangci-lint to lint the entire repo
  - `--new-from-rev HEAD` diffs the whole working tree including unstaged                              
    changes, blocking commits on issues from unrelated in-progress work                                
