### PR TITLE
fix(check-paths): only flag known OS-root absolute paths

### DIFF
--- a/scripts/common/check-paths.sh
+++ b/scripts/common/check-paths.sh
@@ -7,7 +7,10 @@
 
 # Detects hardcoded absolute file paths in staged changes.
 # Catches UNIX absolute paths (/) and Windows absolute paths (C:\).
-# Skips shebangs, URLs, and known safe patterns.
+#
+# UNIX paths are only flagged when rooted in a known OS or user directory
+# name. App-relative paths never match, since their first segment isn't
+# one of those known roots.
 #
 # In staged mode: checks only new lines from the diff.
 # In all mode: checks full file content.
@@ -44,16 +47,12 @@ for f in $CHECK_FILES; do
 
   [ -z "$CONTENT" ] && continue
 
-  # UNIX absolute paths: /word/word starting from root (not relative)
+  # UNIX absolute paths: only flag paths rooted in a known OS/user directory.
   # Requires space, quote, or start-of-line before the leading /
-  # Excludes relative paths (../), command substitutions, .git/ paths
-  UNIX_MATCHES=$(echo "$CONTENT" | grep -E '(^|[[:space:]"'\''=])/[a-zA-Z][a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+' || true)
+  UNIX_MATCHES=$(echo "$CONTENT" | grep -E '(^|[[:space:]"'\''=])/(Users|home|root|tmp|var|etc|opt|usr|mnt|private|Volumes|Library|Applications|System)(/[a-zA-Z0-9._-]+)+' || true)
   UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '^\+?\s*#!' || true)
   UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '://' || true)
-  UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '/dev/null' || true)
   UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '^\+?\s*(#|//|/\*|\*).*example' || true)
-  UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE 'import |from |require\(' || true)
-  UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '/api/|/v[0-9]+/' || true)
   UNIX_MATCHES=$(echo "$UNIX_MATCHES" | grep -vE '\$\(|\.git/' || true)
 
   if [ -n "$UNIX_MATCHES" ]; then

--- a/tests/scripts/common/check-paths.bats
+++ b/tests/scripts/common/check-paths.bats
@@ -64,6 +64,29 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+@test "passes with app-relative asset and route paths" {
+  cat >app.js <<'EOF'
+export const favicon = '/branding/favicon.svg';
+export const ogImage = "/branding/og-image.png";
+export const apiUrl = '/api/users';
+EOF
+  git add app.js
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Path check passed"* ]]
+}
+
+@test "detects hardcoded UNIX absolute path rooted in /home" {
+  # Build path dynamically to avoid triggering the hook on this file
+  printf 'const dir = "%s";\n' "/ho""me/john/projects/app" >app.js
+  git add app.js
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Hardcoded UNIX path"* ]]
+}
+
 @test "skips binary files" {
   echo "binary" >image.png
   git add image.png


### PR DESCRIPTION
## Summary
  - `check-paths.sh` flagged any two-segment leading-slash string as a hardcoded absolute path, so app-relative URLs in web app code (e.g. `/branding/favicon.svg`) were
  false-flagged as personal machine paths like `/Users/john/...`
  - Replaced the denylist approach (match everything, then subtract known-safe patterns like `/api/`, import statements, etc.) with an allowlist: only flag a path when its
  first segment is a known OS/user directory name (`Users`, `home`, `root`, `tmp`, `var`, `etc`, `opt`, `usr`, `mnt`, `private`, `Volumes`, `Library`, `Applications`, `System`)
  - App-relative paths never match those roots, so they pass without needing a maintained exception list going forward

  ## Test plan
  - [x] Added bats cases covering app-relative asset/route paths passing and `/home/...` paths still being caught
  - [x] Full `check-paths.bats` suite passes (15/15)
  - [x] Manually verified against `leaflock-web`'s `config.json` (`/branding/...` paths) — passes clean
  - [x] Manually verified a real leaked path (`/Users/.../projects/app`) is still caught with correct file/line reporting

  Closes #123