### PR TITLE
fix(go-ci): use two-dot diff to avoid merge-base on shallow clones

### DIFF
--- a/.github/workflows/tpl-go-ci.yml
+++ b/.github/workflows/tpl-go-ci.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACMR "$PR_BASE_SHA"...HEAD -- '*.go')
+          FILES=$(git diff --name-only --diff-filter=ACMR "$PR_BASE_SHA"..HEAD -- '*.go')
           echo "changed=$( [ -n "$FILES" ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
 
       - uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
## Summary
  - Fixes #116 (reopened) — the original fix didn't actually resolve the shallow-clone failure
  - `git diff A...B` computes a merge-base of A and B before diffing, which requires shared reachable history between them. On a
  shallow (`fetch-depth: 1`) checkout, fetching just the base SHA (the original #116 fix) makes it exist locally but doesn't connect it
  to `HEAD`'s history, so the merge-base lookup still fails: `fatal: ...HEAD: no merge base`
  - Switched the diff from three-dot (`...`) to two-dot (`..`): `git diff A..B` is a direct tree comparison between two commit objects
  and never computes a merge-base, so it works regardless of shared history — the base-SHA fetch is still needed (both objects must
  exist locally), just the diff itself no longer depends on ancestry between them
