### PR TITLE
fix(ci): install golangci-lint via go install to match target Go version

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2",
   "import": ["configs/common/.cspell.json"],
-  "words": ["pypirc", "winpath", "rojects"],
+  "words": ["pypirc", "winpath", "rojects", "goinstall"],
   "ignorePaths": ["configs/common/LICENSE-apache-2.0"]
 }

--- a/.github/workflows/tpl-go-ci.yml
+++ b/.github/workflows/tpl-go-ci.yml
@@ -112,6 +112,7 @@ jobs:
         if: steps.go-files.outputs.changed == 'true'
         with:
           version: ${{ inputs.golangci-lint-version }}
+          install-mode: goinstall
           working-directory: ${{ inputs.working-directory }}
           only-new-issues: true
 


### PR DESCRIPTION
## Summary
  - Fixes #128
  - `golangci-lint-action`'s default `install-mode: binary` downloads a pre-built release artifact frozen to whatever Go toolchain golangci-lint's own release pipeline used at
  that release's build time — not the Go version the consumer repo actually targets. This breaks once a consumer's `go.mod` targets a newer Go language version than that frozen
  build (`the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.26)`), and no compatible v1.x release exists to pin to instead.
  - Set `install-mode: goinstall` on the `golangci-lint-action@v6` step in the `lint` job. Per the action's own source, this runs `go install
  github.com/golangci/golangci-lint/v2/cmd/golangci-lint@<version>` using whatever `go` is already on `PATH` — already set up earlier in the same job by `actions/setup-go@v5`
  to the consumer repo's own targeted version. Matches what a local `go install`/Homebrew install already does.
  - Added `goinstall` to `.cspell.json`.